### PR TITLE
Upgrades for mongo 8 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongration",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongration",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "async": "~2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "console.table": "^0.10.0",
         "lodash": "^4.17.5",
         "md5": "~2.0.0",
-        "mongodb": "^6.5.0"
+        "mongodb": "^6.13.0"
       },
       "bin": {
         "mongration": "bin/mongration.js"
@@ -707,9 +707,10 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
-      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
+      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
+      "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -1362,9 +1363,10 @@
       "dev": true
     },
     "node_modules/bson": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.5.0.tgz",
-      "integrity": "sha512-DXf1BTAS8vKyR90BO4x5v3rKVarmkdkzwOrnYDFdjAY694ILNDkmA3uRh1xXJEl+C1DAh8XCvAQ+Gh3kzubtpg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.2.tgz",
+      "integrity": "sha512-5afhLTjqDSA3akH56E+/2J6kTDuSIlBxyXPdQslj9hcIgOUE378xdOfZvC/9q3LifJNI6KR/juZ+d0NRNYBwXg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -1842,7 +1844,8 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -1943,12 +1946,13 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
-      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.0.tgz",
+      "integrity": "sha512-KeESYR5TEaFxOuwRqkOm3XOsMqCSkdeDMjaW5u2nuKfX7rqaofp7JQGoi7sVqQcNJTKuveNbzZtWMstb8ABP6Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.4.0",
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.1",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -1956,7 +1960,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
@@ -2143,6 +2147,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -2921,9 +2926,9 @@
       }
     },
     "@mongodb-js/saslprep": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
-      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
+      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -3468,9 +3473,9 @@
       "dev": true
     },
     "bson": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.5.0.tgz",
-      "integrity": "sha512-DXf1BTAS8vKyR90BO4x5v3rKVarmkdkzwOrnYDFdjAY694ILNDkmA3uRh1xXJEl+C1DAh8XCvAQ+Gh3kzubtpg=="
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.2.tgz",
+      "integrity": "sha512-5afhLTjqDSA3akH56E+/2J6kTDuSIlBxyXPdQslj9hcIgOUE378xdOfZvC/9q3LifJNI6KR/juZ+d0NRNYBwXg=="
     },
     "chai": {
       "version": "4.2.0",
@@ -3921,12 +3926,12 @@
       }
     },
     "mongodb": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
-      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.0.tgz",
+      "integrity": "sha512-KeESYR5TEaFxOuwRqkOm3XOsMqCSkdeDMjaW5u2nuKfX7rqaofp7JQGoi7sVqQcNJTKuveNbzZtWMstb8ABP6Q==",
       "requires": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.4.0",
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.1",
         "mongodb-connection-string-url": "^3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongration",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Node.js mongodb migration framework",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "console.table": "^0.10.0",
     "lodash": "^4.17.5",
     "md5": "~2.0.0",
-    "mongodb": "^6.5.0"
+    "mongodb": "^6.13.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Upgrades for mongo 8 support

- Upgraded mongodb to 6.13.0
- Pre-emptively tagged major version for testing parent projects